### PR TITLE
Adds a chivato to pybliotecario 

### DIFF
--- a/src/pybliotecario/backend/facebook_util.py
+++ b/src/pybliotecario/backend/facebook_util.py
@@ -42,7 +42,7 @@ class FacebookMessage(Message):
 
     def _parse_update(self, update):
         """Receives an update in the form of a dictionary (that came from a json)
-        and fills in the _message_dict dictionary
+        and fills the message attributes
         """
         # Check whether it is the correct object, otherwise out
         if update.get("object") != "page":
@@ -54,14 +54,11 @@ class FacebookMessage(Message):
         msg_info = update["entry"][0]["messaging"][0]
         # Check who sent it
         sender_id = msg_info["sender"]["id"]
-        self._message_dict["chat_id"] = sender_id
+        self._chat_id = sender_id
         # Get the msg
         msg = msg_info["message"]
         # get the text and parse it if necessary
-        text = msg.get("text")
-        self._message_dict["text"] = text
-        if text and text.startswith("/"):
-            self._parse_command(text)
+        self._parse_command(msg.get("text"))
         # In facebook we have either text or image
         # TODO: in facebook you can pass more than one img at once...
         attachment = msg.get("attachments")
@@ -69,8 +66,8 @@ class FacebookMessage(Message):
             at_info = attachment[0]
             # Checked for images and files and seems to work
             url = at_info["payload"]["url"]
-            self._message_dict["file_id"] = url
-            self._message_dict["text"] = url.split("?")[0].split("/")[-1]
+            self._file_id = url
+            self._text = url.split("?")[0].split("/")[-1]
 
 
 class FacebookUtil(Backend):

--- a/src/pybliotecario/backend/telegram_util.py
+++ b/src/pybliotecario/backend/telegram_util.py
@@ -148,7 +148,7 @@ class TelegramUtil(Backend):
         """Given a file id, retrieve the URI of the file
         in the remote server
         """
-        url = self.get_file + "?file_id={0}".format(file_id)
+        url = self.get_file + f"?file_id={file_id}"
         jsonret = self.__get_json_from_url(url)
         # was it ok?
         if jsonret["ok"]:
@@ -223,19 +223,18 @@ class TelegramUtil(Backend):
         blabla = requests.post(self.send_doc, data=data)
         logger.info(blabla.status_code, blabla.reason, blabla.content)
 
-    def download_file(self, file_id, file_name):
-        """Download file defined by file_id
-        to given file_name"""
+    def download_file(self, file_id, file_path):
+        """Download file defined by file_id to given file_path"""
         file_url = self._get_filepath(file_id)
         if not file_url:
             return None
         n = 0
-        while os.path.isfile(file_name):
-            filedir = os.path.dirname(file_name)
-            basename = os.path.basename(file_name)
-            file_name = "{0}/n{1}-{2}".format(filedir, n, basename)
+        while file_path.exists():
+            # If the file already exist, iterate it
+            new_name = f"n{n}-{file_path.name}"
+            file_path = file_path.parent / new_name
             n += 1
-        return urllib.request.urlretrieve(file_url, file_name)
+        return urllib.request.urlretrieve(file_url, file_path)
 
 
 if __name__ == "__main__":

--- a/src/pybliotecario/backend/telegram_util.py
+++ b/src/pybliotecario/backend/telegram_util.py
@@ -32,7 +32,7 @@ class TelegramMessage(Message):
 
     def _parse_update(self, update):
         """Receives an update in the form of a dictionary (that came from a json)
-        and fills in the _message_dict dictionary
+        and fills the message attributes
         """
         keys = update.keys()
         # First check whether this is a message, edited message or a channel post
@@ -54,7 +54,7 @@ class TelegramMessage(Message):
             return
         # Now get the chat data and id
         chat_data = message["chat"]
-        self._message_dict["chat_id"] = chat_data["id"]
+        self._chat_id = chat_data["id"]
         # TODO test this part of the parser as this 'from' was a legacy thing at some point
         from_data = message.get("from", chat_data)
 
@@ -62,19 +62,19 @@ class TelegramMessage(Message):
         username = "unknown_user"
         for user_naming in ["last_name", "first_name", "username"]:
             username = from_data.get(user_naming, username)
-        self._message_dict["username"] = username
+        self._username = username
 
         # Check the filetype
         text = None
         if "photo" in message:
             # If it is a photo, get the file id and use the caption as the title
             photo_data = message["photo"][-1]
-            self._message_dict["file_id"] = photo_data["file_id"]
+            self._file_id = photo_data["file_id"]
             text = message.get("caption", "untitled")
         elif "document" in message:
             # If it is a document, telegram gives you everything you need
             file_dict = message["document"]
-            self._message_dict["file_id"] = file_dict["file_id"]
+            self._file_id = file_dict["file_id"]
             text = message.get("caption", None)
             if text is None:
                 # Use the file name
@@ -87,10 +87,9 @@ class TelegramMessage(Message):
         if "group" in chat_data:
             self._group_info = chat_data
 
-        # Finally check whether the message looks like a command
-        self._message_dict["text"] = text
-        if text and text.startswith("/"):
-            self._parse_command(text)
+        # Finally, with the piece of text left, parse the possible command
+        # _parse_command will fill both text and command
+        self._parse_command(text)
 
     @property
     def is_group(self):

--- a/src/pybliotecario/core_loop.py
+++ b/src/pybliotecario/core_loop.py
@@ -1,5 +1,9 @@
+"""
+    This module manages the core loop of the pybliotecario
+    when it is called with daemon mode -d
+"""
 from datetime import datetime
-import os
+from pathlib import Path
 import pybliotecario.on_cmd_message as on_cmd_message
 import logging
 
@@ -10,21 +14,23 @@ _FAILTHRESHOLD = 20
 
 
 def monthly_folder(base_main_folder):
-    main_folder = base_main_folder + "/data"
+    """Receives a path object with the base main folder
+    and returns the monthly folder (also a Path object)"""
+    main_folder = base_main_folder / "data"
     ahora = datetime.now()
     y = ahora.year
     m = ahora.strftime("%B")
-    folder_name = "{0}/{1}/{2}".format(main_folder, y, m)
-    if not os.path.isdir(folder_name):
-        os.makedirs(folder_name)
+    folder_name = main_folder / y / m
+    folder_name.mkdir(exist_ok=True, parents=True)
     return folder_name
 
 
 def write_to_daily_log(main_folder, msg):
+    """Write the msg to the daily log"""
     folder = monthly_folder(main_folder)
     day = datetime.now().day
-    file_name = "{0}/{1}.log".format(folder, day)
-    with open(file_name, "a+") as f:
+    file_name = folder / f"{day}.log"
+    with file_name.open("a+", encoding="utf-8") as f:
         f.write(msg)
         f.write("\n")
 
@@ -67,7 +73,7 @@ def main_loop(tele_api, config=None, clear=False):
     instance of the message as the argument.
     This allows the tele_api to do things asynchronously if needed be
     """
-    main_folder = config["DEFAULT"]["main_folder"]
+    main_folder = Path(config["DEFAULT"]["main_folder"])
 
     except_counter = 0
 
@@ -81,13 +87,16 @@ def main_loop(tele_api, config=None, clear=False):
                 except_counter = 0
                 return
             chat_id = message.chat_id
+
+            # In "chivato" mode, send a message to the main chat_id if sender is not recognized
+
             if message.is_command:
                 # Call the selected command and act on the message
                 on_cmd_message.act_on_telegram_command(tele_api, message, config)
             elif message.is_file:
                 # If the message is a file, save the file and we are done
                 file_name = message.text.replace(" ", "")
-                file_path = "{0}/{1}".format(monthly_folder(main_folder), file_name)
+                file_path = monthly_folder(main_folder) / file_name
                 result = tele_api.download_file(message.file_id, file_path)
                 if result:
                     tele_api.send_message("¡Archivo recibido y guardado!", chat_id)

--- a/src/pybliotecario/core_loop.py
+++ b/src/pybliotecario/core_loop.py
@@ -76,7 +76,7 @@ def main_loop(tele_api, config=None, clear=False):
     main_folder = Path(config["DEFAULT"]["main_folder"])
     accepted_ids = config.getidlist("DEFAULT", "chat_id")
     main_id = config.getmainid("DEFAULT", "chat_id")
-    chivato = config.getboolean("DEFAULT", "chivato")
+    chivato = config.getboolean("DEFAULT", "chivato", fallback=False)
 
     except_counter = 0
 

--- a/src/pybliotecario/customconf.py
+++ b/src/pybliotecario/customconf.py
@@ -22,8 +22,8 @@ def _parse_main_chat_id(value):
 class CustomConfigParser(ConfigParser):
     """Equal to ConfigParser with a number of predefined converters"""
 
-    def __init__(self, *args, converters={}, **kwargs):
+    def __init__(self, *args, converters={}, allow_no_value=True, **kwargs):
         new_converters = copy(converters)
         new_converters.setdefault("idlist", _parse_chat_id)
         new_converters.setdefault("mainid", _parse_main_chat_id)
-        super().__init__(*args, converters=new_converters, **kwargs)
+        super().__init__(*args, converters=new_converters, allow_no_value=allow_no_value, **kwargs)

--- a/src/pybliotecario/customconf.py
+++ b/src/pybliotecario/customconf.py
@@ -1,0 +1,29 @@
+"""
+    Define custom parsers for the config reader
+"""
+from configparser import ConfigParser
+from copy import copy
+
+
+def _parse_chat_id(value):
+    """The chat id can come as a list or as a single value,
+    this ensures that it is always read as a list"""
+    split_values = value.split(",")
+    return [int(i.strip()) for i in split_values]
+
+
+def _parse_main_chat_id(value):
+    """Regardless of the format of the chat id (list or single value)
+    return the main id (i.e., the only one there is or the first one
+    """
+    return _parse_chat_id(value)[0]
+
+
+class CustomConfigParser(ConfigParser):
+    """Equal to ConfigParser with a number of predefined converters"""
+
+    def __init__(self, *args, converters={}, **kwargs):
+        new_converters = copy(converters)
+        new_converters.setdefault("idlist", _parse_chat_id)
+        new_converters.setdefault("mainid", _parse_main_chat_id)
+        super().__init__(*args, converters=new_converters, **kwargs)

--- a/src/pybliotecario/on_cmd_message.py
+++ b/src/pybliotecario/on_cmd_message.py
@@ -31,7 +31,7 @@ def send_help(tele_api, chat_id):
         ("system", "System"),
         ("stocks", "Stocks"),
         ("twitter", "TwitterComponent"),
-        ("photocol", "PhotoCol")
+        ("photocol", "PhotoCol"),
     ]
     full_help = []
     for module, cls in components:

--- a/src/pybliotecario/pybliotecario.py
+++ b/src/pybliotecario/pybliotecario.py
@@ -3,13 +3,13 @@
     Main script for the pybliotecario program
     for command line invocation
 """
-import configparser
 import logging
 import sys
-import os
+from pathlib import Path
 
 from pybliotecario.backend import TelegramUtil, TestUtil, FacebookUtil
 from pybliotecario.core_loop import main_loop
+from pybliotecario.customconf import CustomConfigParser
 
 # Modify argument_parser.py to read new arguments
 from pybliotecario.argument_parser import parse_args, CONFIG_FILE
@@ -20,11 +20,12 @@ logger = logging.getLogger()
 
 def read_config(config_file=None):
     """Reads the pybliotecario config file and uploads the global configuration"""
-    config_files = ["{0}/.{1}".format(os.environ.get("HOME"), CONFIG_FILE), CONFIG_FILE]
+    config_files = [Path.home() / f".{CONFIG_FILE}", CONFIG_FILE]
     if config_file is not None:
         config_files.append(config_file)
-    config = configparser.ConfigParser()
+    config = CustomConfigParser()
     config.read(config_files, encoding="UTF-8")
+    # Add a custom paster to this config
     if config and config.defaults():
         return config
     print("Before using this program you need to run the --init option in order to configure it")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,15 +1,15 @@
 """
     Configuration file for pytest
 """
-import configparser
 import pytest
 
+from pybliotecario.customconf import CustomConfigParser
 from pybliotecario.backend.backend_test import TESTID
 
 
 def generate_fake_config(main_folder):
     """Generate a fake configuration"""
-    config = configparser.ConfigParser()
+    config = CustomConfigParser()
     config["DEFAULT"] = {
         "main_folder": main_folder,
         "token": "AAAaaa123",


### PR DESCRIPTION
When the `chivato` is set to true in the config file (under the `general` section), the pybliotecario will send a msg to the main user when anyone not included in the accepted ids interact with it:

Example:

```ini
[DEFAULT]
chat_id = 1234, 4567
chivato = true
```

In this example the main user is `1234` and they will receive a msg every time an user whose id is not `1234` or `4567` interacts with the pybliotecario,