### PR TITLE
Ignore unknown

### DIFF
--- a/pybliotecario.ini.example
+++ b/pybliotecario.ini.example
@@ -6,7 +6,9 @@ main_folder = /home/<username>/.local/share/pybliotecario
 # quiet defaults to false, whether the bot should always reply back
 quiet = false 
 # when chivato is true, the bot will write to the main chat_id whenever an user not in chat_id writes to the bot
-chivato = false #
+chivato = false
+# if true, messages from chat ids not included in `chat_id` will be ignored
+ignore_unknown = false
 
 [FACEBOOK]
 verify = <verify token from fb>

--- a/pybliotecario.ini.example
+++ b/pybliotecario.ini.example
@@ -1,8 +1,12 @@
 [DEFAULT]
 TOKEN = <telegram bot token>
-chat_id = <chat_id number> 
-main_folder = /home/<username>/.pybliotecario
-
+# chat_id accepts also a list of IDs separated by comma, the first one is considered the main one
+chat_id = <chat_id number>
+main_folder = /home/<username>/.local/share/pybliotecario
+# quiet defaults to false, whether the bot should always reply back
+quiet = false 
+# when chivato is true, the bot will write to the main chat_id whenever an user not in chat_id writes to the bot
+chivato = false #
 
 [FACEBOOK]
 verify = <verify token from fb>

--- a/src/pybliotecario/argument_parser.py
+++ b/src/pybliotecario/argument_parser.py
@@ -1,6 +1,7 @@
 """
     Wrapper for the argument parser and the initialization
 """
+
 from argparse import Action, ArgumentParser, ArgumentTypeError
 import configparser
 import glob
@@ -93,7 +94,7 @@ The instructions on how to get the token can be found here: https://core.telegra
     token = input("Authorization token: ")
 
     # Try to fire up the bot with the given token
-    telegram_API = TelegramUtil(token, timeout=20)
+    telegram_API = TelegramUtil(token=token, timeout=20)
     print("Thanks, let's test this out. Say something (anything!) to your bot in telegram")
 
     for _ in range(20):  # Allow for 20 tries

--- a/src/pybliotecario/backend/basic_backend.py
+++ b/src/pybliotecario/backend/basic_backend.py
@@ -8,6 +8,7 @@
 """
 
 from abc import ABC, abstractmethod
+from configparser import ConfigParser
 import json
 import logging
 import urllib
@@ -160,7 +161,14 @@ class Backend(ABC):
 
     """
 
-    _max_size = 99999
+    def __init__(self, config=None, debug=False, **kwargs):
+        if config is None:
+            # If no config is passed, generate and empty one
+            config = ConfigParser()
+        self._max_size = 99999
+        self._quiet = config.getboolean("DEFAULT", "quiet", fallback=False)
+        self._config = config
+        self._debug = debug
 
     @abstractmethod
     def _get_updates(self, not_empty=False):
@@ -174,6 +182,12 @@ class Backend(ABC):
     @abstractmethod
     def send_message(self, text, chat, **kwargs):
         """Sends a message to the chat"""
+
+    def send_quiet_message(self, text, chat, **kwargs):
+        """Like ``send_message`` but only sends the message if quiet is set to False
+        otherwise, do nothing"""
+        if not self._quiet:
+            return self.send_message(text, chat, **kwargs)
 
     @property
     @abstractmethod

--- a/src/pybliotecario/backend/facebook_util.py
+++ b/src/pybliotecario/backend/facebook_util.py
@@ -196,13 +196,11 @@ class FacebookUtil(Backend):
 
 if __name__ == "__main__":
     from configparser import ConfigParser
+
     logger.info("Testing FB Util")
     verify = "your_verify_token"
     app_token = "your_app_key"
     config = ConfigParser()
-    config["FACEBOOK"] = {
-            "verify": verify,
-            "app_token": app_token
-            }
+    config["FACEBOOK"] = {"verify": verify, "app_token": app_token}
     fb_util = FacebookUtil(config, debug=True)
     fb_util.act_on_updates(lambda x: print(x))

--- a/src/pybliotecario/backend/telegram_util.py
+++ b/src/pybliotecario/backend/telegram_util.py
@@ -106,13 +106,18 @@ class TelegramUtil(Backend):
 
     _message_class = TelegramMessage
 
-    def __init__(self, TOKEN, debug=False, timeout=300):
+    def __init__(self, config=None, token=None, timeout=300, **kwargs):
+        super().__init__(config, **kwargs)
+        if token is None:
+            if config is None:
+                raise ValueError("Either a config or a token must be provided for Telegram")
+            token = config.defaults().get("token")
+
         self.offset = None
-        self.debug = debug
         self.timeout = timeout
         # Build app the API urls
-        base_URL = TELEGRAM_URL + f"bot{TOKEN}/"
-        self.base_fileURL = TELEGRAM_URL + f"file/bot{TOKEN}/"
+        base_URL = TELEGRAM_URL + f"bot{token}/"
+        self.base_fileURL = TELEGRAM_URL + f"file/bot{token}/"
         self.send_msg = base_URL + "sendMessage"
         self.send_img = base_URL + "sendPhoto"
         self.send_doc = base_URL + "sendDocument"
@@ -185,7 +190,7 @@ class TelegramUtil(Backend):
         if not updates and not_empty:
             return self._get_updates(not_empty=True)
 
-        if self.debug:
+        if self._debug:
             logger.info("Request url: %s", url)
             logger.info("Obtained updates: %s", updates)
 
@@ -254,7 +259,7 @@ class TelegramUtil(Backend):
 if __name__ == "__main__":
     logger.info("Testing TelegramUtil")
     token = "must put a token here to test"
-    ut = TelegramUtil(token, debug=True)
+    ut = TelegramUtil(token=token, debug=True)
     # noinspection PyProtectedMember
     results = ut._get_updates()
     for res in results:

--- a/src/pybliotecario/components/component_core.py
+++ b/src/pybliotecario/components/component_core.py
@@ -11,6 +11,7 @@
     the class Component will just pass the text of the msg (or the command)
     to the `act_on_command` or `act_on_message` methods.
 """
+
 import logging
 import os
 import sys
@@ -138,11 +139,15 @@ class Component:
         self.telegram.send_message("Command line argument invoked", self.chat_id)
 
     # Some useful wrappers
-    def send_msg(self, msg, chat_id=None, markdown=False):
+    def send_msg(self, msg, chat_id=None, markdown=False, quiet=False):
         """Wrapper around API send_msg, if chat_id is not defined
-        it will use the chat_id this class was instantiated to"""
+        it will use the chat_id this class was instantiated to.
+        If ``quiet`` == True, use `send_quiet_message`
+        """
         if chat_id is None:
             chat_id = self.interaction_chat
+        if quiet:
+            return self.telegram.send_quiet_message(msg, chat_id, markdown=markdown)
         return self.telegram.send_message(msg, chat_id, markdown=markdown)
 
     def send_img(self, imgpath, chat_id=None, delete=False):

--- a/src/pybliotecario/components/component_core.py
+++ b/src/pybliotecario/components/component_core.py
@@ -173,3 +173,7 @@ class Component:
         self.telegram.send_file(filepath, chat_id)
         if delete:
             os.remove(filepath)
+
+    def _not_allowed_msg(self, chat_id=None):
+        """Tell the calling ID they are not allowed to use this component"""
+        return self.send_msg("You are not allowed to use this", quiet=True, chat_id=chat_id)

--- a/src/pybliotecario/components/dnd.py
+++ b/src/pybliotecario/components/dnd.py
@@ -1,6 +1,7 @@
 """
     Module implementing some functions useful for playing DnD over the internet
 """
+
 import logging
 from random import randint
 import re

--- a/src/pybliotecario/components/github_component.py
+++ b/src/pybliotecario/components/github_component.py
@@ -5,6 +5,7 @@
     https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token
     and follow the instructions
 """
+
 import datetime
 import logging
 

--- a/src/pybliotecario/components/ip_lookup.py
+++ b/src/pybliotecario/components/ip_lookup.py
@@ -25,10 +25,9 @@ class IpLookup(Component):
     def telegram_message(self, msg):
         """If the chat id asking is the correct one
         sends a msg with the current ip, otherwise fails"""
-        if self.check_identity(msg):
-            send_msg = ip_lookup()
-        else:
-            send_msg = "You are not allowed to see this"
+        if not self.check_identity(msg):
+            return self._not_allowed_msg()
+        send_msg = ip_lookup()
         self.telegram.send_message(send_msg, msg.chat_id)
 
     def cmdline_command(self, args):

--- a/src/pybliotecario/components/ip_lookup.py
+++ b/src/pybliotecario/components/ip_lookup.py
@@ -1,4 +1,5 @@
 """ Server-helper function to look up the current IP of the program """
+
 import logging
 import urllib.request
 

--- a/src/pybliotecario/components/photocol.py
+++ b/src/pybliotecario/components/photocol.py
@@ -4,6 +4,7 @@
 
     It's a companion to https://github.com/scarlehoff/websito/blob/master/views/foto.pug
 """
+
 from datetime import datetime
 import json
 import logging

--- a/src/pybliotecario/components/photocol.py
+++ b/src/pybliotecario/components/photocol.py
@@ -107,8 +107,7 @@ class PhotoCol(Component):
             return self.send_msg("Command not understood")
 
         if not self.check_identity(msg):
-            self.send_msg("You are not allowed to interact with this command!")
-            return
+            return self._not_allowed_msg()
 
         if msg.command == "photocol_remove":
             return self._remove_from_db(msg.text)

--- a/src/pybliotecario/components/pid.py
+++ b/src/pybliotecario/components/pid.py
@@ -101,17 +101,16 @@ class ControllerPID(Component):
         return is_it_alive(pid)
 
     def telegram_message(self, msg):
-        if self.check_identity(msg):
-            pid_string = msg.text.strip()
-            if msg.command == "kill_pid":
-                if pid_string.isdigit():
-                    return_msg = self.kill(int(pid_string))
-                else:
-                    return_msg = f"{pid_string} is not a PID?"
-            elif msg.command == "is_pid_alive":
-                return_msg = self.alive(pid_string)
+        if not self.check_identity(msg):
+            return self._not_allowed_msg
+        pid_string = msg.text.strip()
+        if msg.command == "kill_pid":
+            if pid_string.isdigit():
+                return_msg = self.kill(int(pid_string))
             else:
-                return_msg = f"Command {msg.command} not understood?"
+                return_msg = f"{pid_string} is not a PID?"
+        elif msg.command == "is_pid_alive":
+            return_msg = self.alive(pid_string)
         else:
-            return_msg = "You are not allowed to use this"
+            return_msg = f"Command {msg.command} not understood?"
         self.send_msg(return_msg)

--- a/src/pybliotecario/components/scripts.py
+++ b/src/pybliotecario/components/scripts.py
@@ -122,7 +122,7 @@ class Script(Component):
     def telegram_message(self, msg):
         if not self.check_identity(msg) and not self._allow_everyone:
             self.blocked = True
-            self.send_msg("You are not allowed to run scripts here")
+            self._not_allowed_msg()
         if self.blocked:
             return
 

--- a/src/pybliotecario/components/scripts.py
+++ b/src/pybliotecario/components/scripts.py
@@ -3,6 +3,7 @@
     For instant, good_morning will call the command defined in
     /script good_morning will call the command defined in [SCRIPTS] good_morning
 """
+
 import logging
 import pathlib
 import shlex
@@ -148,7 +149,7 @@ class Script(Component):
                     else:
                         cmd_list = [f"./{command_path.name}"] + script_args
                         sp.run(cmd_list, check=True, cwd=command_path.parent)
-                    self.send_msg("Command ran")
+                    self.send_msg("Command ran", quiet=True)
                 except sp.CalledProcessError:
                     self.send_msg("Command ran but failed")
             else:

--- a/src/pybliotecario/components/stocks.py
+++ b/src/pybliotecario/components/stocks.py
@@ -10,6 +10,7 @@
     },
 
 """
+
 import json
 import logging
 

--- a/src/pybliotecario/components/system.py
+++ b/src/pybliotecario/components/system.py
@@ -33,8 +33,7 @@ class System(Component):
     def telegram_message(self, msg):
         # Allow only the main user to use system
         if not self.check_identity(msg):
-            self.send_msg("You are not allowed to run scripts here")
-            return
+            return self._not_allowed_msg()
         command_key = msg.text.strip()
         command_name = ACCEPTED_COMMANDS.get(command_key)
         # Check whether the command is in the accepted_commands dictionary

--- a/src/pybliotecario/components/system.py
+++ b/src/pybliotecario/components/system.py
@@ -2,6 +2,7 @@
     This component contains system-commands to be run
     remotely
 """
+
 import subprocess as sp
 
 from pybliotecario.components.component_core import Component

--- a/src/pybliotecario/components/twitter.py
+++ b/src/pybliotecario/components/twitter.py
@@ -13,6 +13,7 @@
     consumer_secret = <consumer_secret>
     ```
 """
+
 import logging
 
 import tweepy as tw

--- a/src/pybliotecario/core_loop.py
+++ b/src/pybliotecario/core_loop.py
@@ -2,6 +2,7 @@
     This module manages the core loop of the pybliotecario
     when it is called with daemon mode -d
 """
+
 from datetime import datetime
 import logging
 from pathlib import Path
@@ -119,7 +120,7 @@ def main_loop(tele_api, config=None, clear=False):
                 # Otherwise just save the msg to the log and send a funny reply
                 _write_to_daily_log(main_folder, message.text)
                 random_msg = still_alive()
-                tele_api.send_message(random_msg, chat_id)
+                tele_api.send_quiet_message(random_msg, chat_id)
             except_counter = 0
         except Exception as e:
             logger.error(f"This message produced an exception: {e}")

--- a/src/pybliotecario/core_loop.py
+++ b/src/pybliotecario/core_loop.py
@@ -110,7 +110,7 @@ def main_loop(tele_api, config=None, clear=False):
                 file_path = _monthly_folder(main_folder) / file_name
                 result = tele_api.download_file(message.file_id, file_path)
                 if result:
-                    tele_api.send_message("¡Archivo recibido y guardado!", chat_id)
+                    tele_api.send_quiet_message("¡Archivo recibido y guardado!", chat_id)
                     logger.info("File saved to %s", file_path)
                 else:
                     tele_api.send_message("There was some problem with this, sorry", chat_id)

--- a/src/pybliotecario/core_loop.py
+++ b/src/pybliotecario/core_loop.py
@@ -79,6 +79,7 @@ def main_loop(tele_api, config=None, clear=False):
     accepted_ids = config.getidlist("DEFAULT", "chat_id")
     main_id = config.getmainid("DEFAULT", "chat_id")
     chivato = config.getboolean("DEFAULT", "chivato", fallback=False)
+    ignore_unknown = config.getboolean("DEFAULT", "ignore_unknown", fallback=False)
 
     global except_counter
     except_counter = 0
@@ -96,10 +97,14 @@ def main_loop(tele_api, config=None, clear=False):
             chat_id = message.chat_id
 
             # In "chivato" mode, send a message to the main chat_id if sender is not recognized
-            if chivato and chat_id not in accepted_ids:
-                chivato_msg = f"""El usuario @{message.username} ({chat_id=}) ha enviado el siguiente mensaje:
-{message.raw}"""
-                tele_api.send_message(chivato_msg, main_id)
+            if chat_id not in accepted_ids:
+                if chivato:
+                    chivato_msg = f"""El usuario @{message.username} ({chat_id=}) ha enviado el siguiente mensaje:
+        {message.raw}"""
+                    tele_api.send_message(chivato_msg, main_id)
+                if ignore_unknown:
+                    logger.info(f"Chat id {chat_id} not known, ignoring")
+                    return
 
             if message.is_command:
                 # Call the selected command and act on the message

--- a/src/pybliotecario/customconf.py
+++ b/src/pybliotecario/customconf.py
@@ -2,6 +2,7 @@
     Define custom parsers for the config reader
     and default data/config locations
 """
+
 from configparser import ConfigParser
 from copy import copy
 from os import environ

--- a/src/pybliotecario/on_cmd_message.py
+++ b/src/pybliotecario/on_cmd_message.py
@@ -6,6 +6,7 @@
     This is a design choice as this way it is not necessary to have all dependencies
     if you want to run only some submodules of the pybliotecario.
 """
+
 import importlib
 import logging
 

--- a/src/pybliotecario/pybliotecario.py
+++ b/src/pybliotecario/pybliotecario.py
@@ -18,7 +18,7 @@ logger = logging.getLogger()
 
 
 def read_config(config_file=None):
-    """Reads the pybliotecario config file and uploads the global configuration
+    """Reads the pybliotecario config file and updates the global configuration
     By default looks always in the default file path (in XDG_CONFIG_HOME) and the current folder
     """
     default_file_path = default_config_path()
@@ -107,19 +107,13 @@ def main(cmdline_arg=None, tele_api=None, config=None):
                 )
                 sys.exit(-1)
 
-            tele_api = TelegramUtil(api_token, debug=args.debug)
+            tele_api = TelegramUtil(config=config, debug=args.debug)
         elif args.backend.lower() == "test":
             tele_api = TestUtil("/tmp/test_file.txt")
         elif args.backend.lower() == "facebook":
-            try:
-                fb_config = config["FACEBOOK"]
-            except KeyError:
-                raise ValueError("No facebook section found for facebook in pybliotecario.ini")
-            verify_token = fb_config.get("verify")
-            app_token = fb_config.get("app_token")
-            tele_api = FacebookUtil(app_token, verify_token, debug=args.debug)
+            tele_api = FacebookUtil(config=config, debug=args.debug)
             # Check whether we have chat id
-            chat_id = fb_config.get("chat_id")
+            chat_id = config["FACEBOOK"].get("chat_id")
             if chat_id is not None:
                 config.set("DEFAULT", "chat_id", chat_id)
 


### PR DESCRIPTION
With the option `ignore_unknown`, messages arriving to the bot from an ID not included in `chat_id` will be immediately dropped.

If `chivato` is `True`, the main user will still get a notification about someone trying to use the bot.